### PR TITLE
Correction of evaluation metric

### DIFF
--- a/evaluation.py
+++ b/evaluation.py
@@ -19,8 +19,8 @@ def get_sensitivity(SR,GT,threshold=0.5):
 
     # TP : True Positive
     # FN : False Negative
-    TP = ((SR==1)+(GT==1))==2
-    FN = ((SR==0)+(GT==1))==2
+    TP = (SR==1)&(GT==1)
+    FN = (SR==0)&(GT==1)
 
     SE = float(torch.sum(TP))/(float(torch.sum(TP+FN)) + 1e-6)     
     
@@ -32,8 +32,8 @@ def get_specificity(SR,GT,threshold=0.5):
 
     # TN : True Negative
     # FP : False Positive
-    TN = ((SR==0)+(GT==0))==2
-    FP = ((SR==1)+(GT==0))==2
+    TN = (SR==0)&(GT==0)
+    FP = (SR==1)&(GT==0)
 
     SP = float(torch.sum(TN))/(float(torch.sum(TN+FP)) + 1e-6)
     
@@ -45,8 +45,8 @@ def get_precision(SR,GT,threshold=0.5):
 
     # TP : True Positive
     # FP : False Positive
-    TP = ((SR==1)+(GT==1))==2
-    FP = ((SR==1)+(GT==0))==2
+    TP = (SR==1)&(GT==1)
+    FP = (SR==1)&(GT==0)
 
     PC = float(torch.sum(TP))/(float(torch.sum(TP+FP)) + 1e-6)
 
@@ -66,8 +66,8 @@ def get_JS(SR,GT,threshold=0.5):
     SR = SR > threshold
     GT = GT == torch.max(GT)
     
-    Inter = torch.sum((SR+GT)==2)
-    Union = torch.sum((SR+GT)>=1)
+    Inter = torch.sum(SR&GT)
+    Union = torch.sum(SR|GT)
     
     JS = float(Inter)/(float(Union) + 1e-6)
     
@@ -78,10 +78,7 @@ def get_DC(SR,GT,threshold=0.5):
     SR = SR > threshold
     GT = GT == torch.max(GT)
 
-    Inter = torch.sum((SR+GT)==2)
+    Inter = torch.sum(SR&GT)
     DC = float(2*Inter)/(float(torch.sum(SR)+torch.sum(GT)) + 1e-6)
 
     return DC
-
-
-


### PR DESCRIPTION
tested on pytorch==1.2.0
ISIC 2018 dataset first loop result[All default]:
Epoch [1/150], Loss: 570.2478, 
[Training] Acc: 0.8824, SE: 0.7623, SP: 0.9695, PC: 0.7704, F1: 0.6987, JS: 0.5823, DC: 0.6987
[Validation] Acc: 0.8595, SE: 0.5696, SP: 0.9477, PC: 0.7414, F1: 0.5573, JS: 0.4587, DC: 0.5573
Best R2AttU_Net model score : 1.0160


tested on pytorch==1.5.0
ISIC 2018 dataset first loop result[All default]:
Epoch [1/200], Loss: 454.9332, 
[Training] Acc: 0.9083, SE: 0.7878, SP: 0.9756, PC: 0.8060, F1: 0.7414, JS: 0.6310, DC: 0.7414
[Validation] Acc: 0.8288, SE: 0.3145, SP: 0.9982, PC: 0.6754, F1: 0.3814, JS: 0.2991, DC: 0.3814